### PR TITLE
Fixes eslint error from typescript definition @typescript-eslint/unbound-method

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -19,13 +19,13 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   recentlySuccessful: boolean
   setData: setDataByObject<TForm> & setDataByMethod<TForm> & setDataByKeyValuePair<TForm>
   transform: (callback: (data: TForm) => TForm) => void
-  setDefaults(): void
-  setDefaults(field: keyof TForm, value: FormDataConvertible): void
-  setDefaults(fields: Partial<TForm>): void
+  setDefaults: () => void
+  setDefaults: (field: keyof TForm, value: FormDataConvertible) => void
+  setDefaults: (fields: Partial<TForm>) => void
   reset: (...fields: (keyof TForm)[]) => void
   clearErrors: (...fields: (keyof TForm)[]) => void
-  setError(field: keyof TForm, value: string): void
-  setError(errors: Record<keyof TForm, string>): void
+  setError: (field: keyof TForm, value: string) => void
+  setError: (errors: Record<keyof TForm, string>) => void
   submit: (method: Method, url: string, options?: VisitOptions) => void
   get: (url: string, options?: VisitOptions) => void
   patch: (url: string, options?: VisitOptions) => void


### PR DESCRIPTION
I’m pretty sure the solution would be super easy, by defining the setDefault methods with the braces after colon instead of before.

e.g. from current inertia types:
```
setDefaults(): void;
setDefaults(field: keyof TForm, value: FormDataConvertible): void;
setDefaults(fields: Partial<TForm>): void;
```

to:
```
setDefaults: () => void;
setDefaults: (field: keyof TForm, value: FormDataConvertible) => void;
setDefaults: (fields: Partial<TForm>) => void;
```

I’ve was trying to find some documentation on setDefaults(): void; vs setDefaults: () => void; and I think it’s just that setDefaults(): void;would be used in an interface that gets implemented by a class to describe its shape and public methods (e.g. class Bla implements MyInterface), and in this case setDefaults(): void; on the interface indicates a public method available on the class.

Now looking at the vendor code, the interface isn’t used to indicate a class implementation, instead it’s used to type some react props, so I think it may just be a simple change.